### PR TITLE
update the github theme_settings to bytecodealliance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ plugins:
   - jekyll-include-cache
 
 theme_settings:
-  github: CraneStation/wasi
+  github: bytecodealliance/wasi
   avatar: polyfill/WASI-small.png
 
 exclude:


### PR DESCRIPTION
The GitHub link at the top-right of the https://wasi.dev/ website links to https://github.com/CraneStation/wasi which I believe should be updated to https://github.com/bytecodealliance/wasi

This PR makes that simple change :)