### PR TITLE
fix: broken link to wasi meetings

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ header_text_feature_image: polyfill/WASI-small.png
 
 WASI is a modular system interface for WebAssembly. As described in [the initial announcement](https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/), it's focused on security and portability.
 
-WASI is being standardized in [a subgroup of the WebAssembly CG](https://github.com/WebAssembly/WASI/blob/master/Charter.md). Discussions happen in [GitHub issues](https://github.com/WebAssembly/WASI/issues), [pull requests](https://github.com/WebAssembly/WASI/pulls), and [bi-weekly Zoom meetings](https://github.com/WebAssembly/WASI/tree/master/meetings).
+WASI is being standardized in [a subgroup of the WebAssembly CG](https://github.com/WebAssembly/WASI/blob/master/Charter.md). Discussions happen in [GitHub issues](https://github.com/WebAssembly/WASI/issues), [pull requests](https://github.com/WebAssembly/WASI/pulls), and [bi-weekly Zoom meetings](https://github.com/WebAssembly/meetings/tree/main/wasi).
 
 For a quick intro to WASI, including getting started using it, see [the intro document](https://github.com/bytecodealliance/wasmtime/blob/main/docs/WASI-intro.md).
 


### PR DESCRIPTION
The meetings page was moved, which broke the link on the site.